### PR TITLE
Day 7 - feat(agents): stricter web-search + guaranteed handoff to Agent 2 + MD render

### DIFF
--- a/day-1-ai-chat-nextgen/app/build.gradle.kts
+++ b/day-1-ai-chat-nextgen/app/build.gradle.kts
@@ -174,6 +174,8 @@ dependencies {
 
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    // Markdown rendering
+    implementation(libs.markwon.core)
 }
 
 // Allow references to generated code

--- a/day-1-ai-chat-nextgen/app/src/main/java/com/example/day1_ai_chat_nextgen/domain/model/AgentPrompts.kt
+++ b/day-1-ai-chat-nextgen/app/src/main/java/com/example/day1_ai_chat_nextgen/domain/model/AgentPrompts.kt
@@ -23,6 +23,38 @@ object AgentPrompts {
         In NON-final messages, NEVER write HANDOFF_AGENT2.
         Do not add any prefixes/suffixes/code blocks around the useful text.
 
+        HANDOFF RULES (STRICT):
+        - The token HANDOFF_AGENT2 MUST be the very first characters of the message.
+        - No spaces, newlines, punctuation or any text BEFORE it (not even a blank line).
+        - If you are not 100% ready to hand off, DO NOT output HANDOFF_AGENT2 anywhere.
+        - In non-final messages, do not mention the token at all.
+        - Valid example (exact):
+          HANDOFF_AGENT2
+          <full payload for Agent 2>
+        - Invalid (do not do this):
+          Some text...\nHANDOFF_AGENT2\n... (marker not at the beginning)
+          \nHANDOFF_AGENT2\n... (blank line before marker)
+
+        IMPORTANT STYLE:
+        - Do NOT summarize or compress information. Avoid brevity.
+        - Your role is to collect/clarify and pass raw, useful excerpts/quotes and context to Agent 2.
+        - If you include material from web search, prefer verbatim excerpts over your own paraphrase (short quoted fragments are OK).
+        - Avoid bullet lists; write plain text with short quoted fragments if needed.
+        - Let Agent 2 do the aggressive summarization and final style.
+
+        WHEN TO USE THE WEB TOOL:
+        - If the user explicitly asks to search (e.g., "ищи", "найди", "поиск", "в интернете", "гуглни", "свежие новости"),
+          or asks for up-to-date facts, YOU MUST invoke the tool immediately.
+        - Never say that you cannot browse or have no internet. If search is needed, emit ACTION/ARGS and wait for OBSERVATION.
+        - Produce the tool call in the strict format below (no code blocks, one item per line).
+
+        HARD CONSTRAINT WHEN SEARCH IS REQUESTED:
+        - Output EXACTLY THREE LINES and NOTHING ELSE:
+          THOUGHT: <why you need to search>
+          ACTION: web.search
+          ARGS: {"query":"<string>", "top_k": <int>}
+        - Do not add apologies, disclaimers or any extra text before/after these three lines.
+
         If you need fresh factual information from the web, use the tool protocol strictly:
         1) THOUGHT: <why you need to search>
         2) ACTION: web.search
@@ -32,18 +64,22 @@ object AgentPrompts {
         """
     ).trimIndent()
 
-    // Agent 2 — Clown Style Rewriter
+    // Agent 2 — Clown Style Summarizer
     val AGENT_2_SYSTEM_PROMPT: String = (
         """
-        Role: Clown Style Rewriter.
+        Role: Clown Style Summarizer.
 
-        You receive ARBITRARY text (without code words).
-        Rewrite it in a clown style: playful, loud, with appropriate emojis 🤡🎪🎈,
-        but retain the original meaning and key facts.
-        Preserve the structure (headings, lists) if possible.
-        If there were steps/instructions — keep them, but present them humorously.
-        Do not add unnecessary warnings/disclaimers.
-        The response should consist only of the rewritten text (without explanations).
+        You receive:
+        - SOURCES: a numbered list of sources (title + URL + optional content excerpt)
+        - PAYLOAD: user-facing text from Agent 1
+
+        Task:
+        - Produce ONE concise summary immediately in clown style (playful, loud, appropriate emojis 🤡🎪🎈).
+        - Use 3–5 bullet points; EACH bullet ≤ 12 words, no filler.
+        - Include simple citations [1], [2], ... linked to SOURCES when a fact is taken from a source.
+        - Do not invent facts. If a fact is unknown from SOURCES, say “неизвестно” without guessing.
+        - Be strictly shorter and more compact than the provided content.
+        - No extra sections, no headings, no explanations. Output ONLY the bullet list.
         """
     ).trimIndent()
 

--- a/day-1-ai-chat-nextgen/app/src/main/java/com/example/day1_ai_chat_nextgen/presentation/components/MessageBubble.kt
+++ b/day-1-ai-chat-nextgen/app/src/main/java/com/example/day1_ai_chat_nextgen/presentation/components/MessageBubble.kt
@@ -19,6 +19,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.day1_ai_chat_nextgen.domain.model.ChatMessage
 import com.example.day1_ai_chat_nextgen.domain.model.MessageRole
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import io.noties.markwon.Markwon
+import androidx.compose.ui.graphics.toArgb
 
 @Stable
 data class MessageBubbleColors(
@@ -73,13 +77,20 @@ fun MessageBubble(
                     ),
                     elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
                 ) {
-                    Text(
-                        text = message.content,
+                    val context = LocalContext.current
+                    AndroidView(
                         modifier = Modifier.padding(12.dp),
-                        color = colors.textColor,
-                        fontSize = 16.sp,
-                        fontWeight = if (message.role == MessageRole.SYSTEM) FontWeight.Medium else FontWeight.Normal,
-                        lineHeight = 20.sp
+                        factory = {
+                            android.widget.TextView(it).apply {
+                                setTextColor(colors.textColor.toArgb())
+                                textSize = 16f
+                                setLineSpacing(0f, 1.25f)
+                            }
+                        },
+                        update = { tv ->
+                            val markwon = Markwon.create(context)
+                            markwon.setMarkdown(tv, message.content)
+                        }
                     )
                 }
             }

--- a/day-1-ai-chat-nextgen/gradle/libs.versions.toml
+++ b/day-1-ai-chat-nextgen/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ coroutinesTest = "1.7.3"
 ksp = "2.1.10-1.0.30"
 detekt = "1.23.7"
 archunit = "1.3.0"
+markwon = "4.6.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -84,6 +85,7 @@ kotest-assertions = { group = "io.kotest", name = "kotest-assertions-core", vers
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 archunit-junit4 = { group = "com.tngtech.archunit", name = "archunit-junit4", version.ref = "archunit" }
+markwon-core = { group = "io.noties.markwon", name = "core", version.ref = "markwon" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/day-1-ai-chat-nextgen/memory-bank/activeContext.md
+++ b/day-1-ai-chat-nextgen/memory-bank/activeContext.md
@@ -28,8 +28,12 @@
 - MCP integration for Agent 1 (web search):
   - Локальный HTTP шлюз `day-6-mcp` (FastAPI, DDG/Wikipedia; опционально enrichment первой страницы)
   - В приложении: `McpBridgeApi`, DTO и DI; debug `BuildConfig.MCP_BRIDGE_URL = http://10.0.2.2:8765/`
-  - Репозиторий: парсит `ACTION: web.search`, вызывает шлюз с `enrich=true`, публикует `OBSERVATION:` и перезапускает ран
+  - Репозиторий: парсит `ACTION: web.search`, вызывает шлюз с `enrich=true`, публикует `OBSERVATION:` и перезапускает ран; если Агент 1 не сделал HANDOFF — выполняется принудительный handoff с `SOURCES+PAYLOAD` к Агенту 2
   - `OBSERVATION:` содержит заголовки/URL и до 1000 символов контента
+
+- Агентные промпты:
+  - Агент 1: жёсткие правила HANDOFF (строго в начале сообщения) и обязательный вызов инструмента при явной просьбе «ищи/найди/свежие новости…», формат вывода при запросе — только THOUGHT/ACTION/ARGS
+  - Агент 2: вместо двух фаз сразу выдаёт короткую сводку клоунским стилем (3–5 пунктов, ≤12 слов), с ссылками [n] на источники
 
 ## Next Steps
 - UI toggle for enabling/disabling dual-agents mode (MVP: always on)

--- a/day-1-ai-chat-nextgen/memory-bank/progress.md
+++ b/day-1-ai-chat-nextgen/memory-bank/progress.md
@@ -13,6 +13,8 @@
  - System badges: "Передача сообщения во 2-го агента" and "Сообщение принято агентом 2" (до ответа А2)
  - Immediate local persistence of user message to prevent disappearance on refresh
  - MCP web-search MVP for Agent 1 via local gateway (Docker): ACTION/ARGS/OBSERVATION loop, results with titles/URLs; enrichment returns content excerpt
+- Forced handoff: если Агент 1 не ставит HANDOFF, репозиторий передаёт SOURCES+PAYLOAD Агенту 2 автоматически
+- Агент 2: сразу выдаёт краткую выжимку клоунским стилем (3–5 пунктов, ≤12 слов, с [n]-ссылками)
 
 ## What's Left
 - Fix intermittent format indicator visibility after New Thread.

--- a/day-6-mcp/Dockerfile
+++ b/day-6-mcp/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 RUN pip install --no-cache-dir fastapi uvicorn[standard] httpx duckduckgo_search==6.1.7 \
-    beautifulsoup4 lxml
+    beautifulsoup4 lxml readability-lxml
 
 COPY server.py /app/server.py
 


### PR DESCRIPTION
- Кратко:
Внедрены правила для надёжного поиска и передачи управления второму агенту. Агент 1 вызывает инструмент при явном запросе (“ищи/найди/свежие новости”), HANDOFF строго в начале сообщения. Агент 2 сразу выдаёт краткую клоун‑сводку. В UI добавлена поддержка Markdown.

- Изменения:
  - Agent 1 prompt:
    - Обязательный ACTION для явных поисковых запросов; формат вывода ровно THOUGHT/ACTION/ARGS.
    - HANDOFF_AGENT2 допускается только в самом начале сообщения, без текста до него.
  - Repo:
    - Сбор источников из OBSERVATION.
  - Agent 2 prompt:
    - Мгновенная выжимка в клоунском стиле: 3–5 буллетов, ≤12 слов, ссылки [n].
  - MCP gateway:
    - Readability‑извлечение текста с первой валидной страницы, follow redirects, фильтр SERP.
  - UI:
    - Markwon для Markdown; фикс цвета текста.

- Проверка:
  - “Найди свежие новости о X” → ACTION/ARGS → OBSERVATION → SOURCES+PAYLOAD → Агент 2 возвращает 3–5 клоун‑буллетов с [n].
  - Markdown отображается в чат‑баблах.

- Риски:
  - Рост токенов из‑за SOURCES: ограничение длины и числа источников.
  - Поведение модели: жёсткие правила в промпте + репозиторная «аварийная» передача.

- Follow-ups:
  - Подключить Brave/SerpAPI ключи.
  - Конфигурируемый `enrich` и лимиты.
  - Тесты на парсинг ACTION/ARGS и forced handoff.